### PR TITLE
feat(entries): core repo + basic home & editor

### DIFF
--- a/lib/app/constants/app_icons.dart
+++ b/lib/app/constants/app_icons.dart
@@ -17,12 +17,13 @@ class AppIcons {
   static const search = Icons.search;
 
   // Notes
-  static const check = Icons.check;
+  static const note = Icons.menu_book_rounded;
 
   // Media
   static const image = Icons.image_outlined;
 
   // UI / Misc
+  static const check = Icons.check;
   static const circle = Icons.circle;
   static const settings = Icons.settings;
   static const delete = Icons.delete_outline;

--- a/lib/app/router/router.dart
+++ b/lib/app/router/router.dart
@@ -12,6 +12,7 @@ import 'package:havenote/features/auth/presentation/reauth_screen.dart';
 import 'package:havenote/features/auth/presentation/sign_in_screen.dart';
 import 'package:havenote/features/auth/presentation/sign_up_screen.dart';
 import 'package:havenote/features/auth/presentation/verify_email_screen.dart';
+import 'package:havenote/features/editor/presentation/editor_screen.dart';
 import 'package:havenote/features/home/presentation/home_screen.dart';
 import 'package:havenote/features/settings/presentation/settings_screen.dart';
 import 'package:havenote/features/splash/presentation/splash_screen.dart';
@@ -91,6 +92,11 @@ final routerProvider = Provider<GoRouter>((ref) {
         name: AppRouteName.reauth,
         path: AppRoutePath.reauth,
         builder: (_, __) => const ReauthScreen(),
+      ),
+      GoRoute(
+        name: AppRouteName.editor,
+        path: AppRoutePath.editor,
+        builder: (_, __) => const EditorScreen(),
       ),
     ],
 

--- a/lib/app/router/routes.dart
+++ b/lib/app/router/routes.dart
@@ -9,6 +9,7 @@ abstract class AppRouteName {
   static const forgotPassword = 'forgotpassword';
   static const reauth = 'reauth';
   static const home = 'home';
+  static const editor = 'editor';
   static const settings = 'settings';
 }
 
@@ -21,6 +22,7 @@ abstract class AppRoutePath {
   static const forgotPassword = '/auth/forgot-password';
   static const reauth = '/auth/reauth';
   static const home = '/home';
+  static const editor = '/editor';
   static const settings = '/settings';
 }
 
@@ -36,4 +38,7 @@ abstract class AppRoute {
   static String reauth() => AppRoutePath.reauth;
   static String home() => AppRoutePath.home;
   static String settings() => AppRoutePath.settings;
+
+  /// New note (create)
+  static String editorNew() => AppRoutePath.editor;
 }

--- a/lib/data/entries/firestore_entries_repository.dart
+++ b/lib/data/entries/firestore_entries_repository.dart
@@ -1,0 +1,69 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:havenote/domain/entries/i_entries_repository.dart';
+import 'package:havenote/domain/entries/models/entry.dart';
+
+class FirestoreEntriesRepository implements IEntriesRepository {
+  FirestoreEntriesRepository(this._db, this._auth);
+
+  final FirebaseFirestore _db;
+  final FirebaseAuth _auth;
+
+  CollectionReference<Map<String, dynamic>> _entriesCollection() {
+    final uid = _auth.currentUser?.uid;
+    if (uid == null) {
+      throw StateError('No user');
+    }
+    return _db.collection('users').doc(uid).collection('entries');
+  }
+
+  /// Stream of all entries
+  @override
+  Stream<List<Entry>> watchEntries() {
+    final q = _entriesCollection().orderBy('createdAt', descending: true);
+    return q.snapshots().map((s) {
+      final list = s.docs.map(Entry.fromDoc).toList();
+      return list;
+    });
+  }
+
+  /// Stream of a single entry by id (nullable if the doc is missing/deleted).
+  @override
+  Stream<Entry?> watchEntry(String id) {
+    return _entriesCollection()
+        .doc(id)
+        .snapshots()
+        .map((d) => d.exists ? Entry.fromDoc(d) : null);
+  }
+
+  /// Creates a new entry and returns its id.
+  @override
+  Future<String> createEntry({
+    required String title,
+    required String body,
+    List<String> tags = const [],
+    String? mood,
+  }) async {
+    final ref = await _entriesCollection().add({
+      'title': title,
+      'body': body,
+      'tags': tags,
+      'mood': mood,
+      'images': [],
+      'createdAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+      'deletedAt': null,
+    });
+    return ref.id;
+  }
+
+  /// Updates an existing entry. `createdAt` is not modified; `updatedAt` is set to server timestamp.
+  @override
+  Future<void> updateEntry(Entry entry) async {
+    final data =
+        entry.toMap()
+          ..remove('createdAt')
+          ..['updatedAt'] = FieldValue.serverTimestamp();
+    await _entriesCollection().doc(entry.id).update(data);
+  }
+}

--- a/lib/domain/entries/i_entries_repository.dart
+++ b/lib/domain/entries/i_entries_repository.dart
@@ -1,0 +1,20 @@
+import 'package:havenote/domain/entries/models/entry.dart';
+
+abstract class IEntriesRepository {
+  /// Stream of all entries
+  Stream<List<Entry>> watchEntries();
+
+  /// Stream of a single entry by id (nullable if the doc is missing/deleted).
+  Stream<Entry?> watchEntry(String id);
+
+  /// Creates a new entry and returns its id.
+  Future<String> createEntry({
+    required String title,
+    required String body,
+    List<String> tags = const [],
+    String? mood,
+  });
+
+  /// Partial or full update; repo guarantees `updatedAt` server timestamp.
+  Future<void> updateEntry(Entry entry);
+}

--- a/lib/domain/entries/models/entry.dart
+++ b/lib/domain/entries/models/entry.dart
@@ -1,0 +1,74 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class Entry {
+  Entry({
+    required this.id,
+    required this.title,
+    required this.body,
+    this.tags = const [],
+    this.mood,
+    this.createdAt,
+    this.updatedAt,
+    this.deletedAt,
+  });
+
+  final String id;
+  final String title;
+  final String body;
+  final List<String> tags;
+  final String? mood;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+  final DateTime? deletedAt;
+
+  Map<String, dynamic> toMap() {
+    return {
+      'title': title,
+      'body': body,
+      'tags': tags,
+      'mood': mood,
+      'createdAt': createdAt,
+      'updatedAt': updatedAt,
+      'deletedAt': deletedAt,
+    };
+  }
+
+  static Entry fromDoc(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data() ?? {};
+    final created = data['createdAt'];
+    final updated = data['updatedAt'];
+    final deleted = data['deletedAt'];
+
+    return Entry(
+      id: doc.id,
+      title: (data['title'] as String? ?? '').trim(),
+      body: (data['body'] as String? ?? '').trim(),
+      tags: (data['tags'] as List<dynamic>? ?? []).cast<String>(),
+      mood: data['mood'] as String?,
+      createdAt: created is Timestamp ? created.toDate() : null,
+      updatedAt: updated is Timestamp ? updated.toDate() : null,
+      deletedAt: deleted is Timestamp ? deleted.toDate() : null,
+    );
+  }
+
+  Entry copyWith({
+    String? title,
+    String? body,
+    List<String>? tags,
+    String? mood,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    DateTime? deletedAt,
+  }) {
+    return Entry(
+      id: id,
+      title: title ?? this.title,
+      body: body ?? this.body,
+      tags: tags ?? this.tags,
+      mood: mood ?? this.mood,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      deletedAt: deletedAt ?? this.deletedAt,
+    );
+  }
+}

--- a/lib/features/editor/presentation/editor_screen.dart
+++ b/lib/features/editor/presentation/editor_screen.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:havenote/app/constants/app_icons.dart';
+import 'package:havenote/app/constants/app_sizes.dart';
+import 'package:havenote/features/editor/presentation/widgets/editor_fields.dart';
+import 'package:havenote/features/editor/state/editor_controller.dart';
+import 'package:havenote/features/entries/state/entries_providers.dart';
+import 'package:havenote/l10n/app_localizations.dart';
+
+class EditorScreen extends ConsumerStatefulWidget {
+  const EditorScreen({super.key, this.entryId});
+  final String? entryId;
+
+  @override
+  ConsumerState<EditorScreen> createState() => _EditorScreenState();
+}
+
+class _EditorScreenState extends ConsumerState<EditorScreen> {
+  final _title = TextEditingController();
+  final _body = TextEditingController();
+  final _tag = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    // Prefill for edit mode
+    if (widget.entryId != null) {
+      ref
+          .read(entriesRepositoryProvider)
+          .watchEntry(widget.entryId!)
+          .first
+          .then((e) {
+            if (!mounted || e == null) return;
+            _title.text = e.title;
+            _body.text = e.body;
+            if (e.tags.isNotEmpty) _tag.text = e.tags.first;
+            ref.read(editorControllerProvider.notifier).setMood(e.mood);
+          });
+    }
+  }
+
+  @override
+  void dispose() {
+    _title.dispose();
+    _body.dispose();
+    _tag.dispose();
+    super.dispose();
+  }
+
+  Future<void> _onSave() async {
+    final t = S.of(context);
+    final ctl = ref.read(editorControllerProvider.notifier);
+
+    final safeTitle =
+        _title.text.trim().isEmpty ? t.labelUntitled : _title.text.trim();
+    final body = _body.text.trim();
+    final tags =
+        _tag.text.trim().isEmpty
+            ? const <String>[]
+            : <String>[_tag.text.trim()];
+
+    try {
+      await ctl.save(
+        entryId: widget.entryId,
+        title: safeTitle,
+        body: body,
+        tags: tags,
+      );
+      if (!mounted) return;
+      Navigator.of(context).pop();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('${t.errorGeneric}: $e')));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final t = S.of(context);
+    final editorState = ref.watch(editorControllerProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          widget.entryId == null ? t.labelNewEntry : t.labelEditEntry,
+        ),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(AppSizes.padding),
+        children: [
+          TitleField(controller: _title, label: t.labelTitle),
+          const SizedBox(height: AppSizes.spaceSM),
+          BodyField(controller: _body, label: t.labelBody),
+          const SizedBox(height: AppSizes.spaceSM),
+          Row(
+            children: [
+              MoodPicker(
+                value: editorState.mood,
+                onChanged:
+                    (v) =>
+                        ref.read(editorControllerProvider.notifier).setMood(v),
+                label: t.labelMood,
+              ),
+              const SizedBox(width: AppSizes.spaceSM),
+              Expanded(child: TagField(controller: _tag, label: t.labelTag)),
+            ],
+          ),
+          const SizedBox(height: AppSizes.space),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton.icon(
+              onPressed: editorState.isSaving ? null : _onSave,
+              icon:
+                  editorState.isSaving
+                      ? const SizedBox(
+                        height: AppSizes.iconSM,
+                        width: AppSizes.iconSM,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                      : const Icon(AppIcons.check),
+              label: Text(t.actionSave),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/editor/presentation/widgets/editor_fields.dart
+++ b/lib/features/editor/presentation/widgets/editor_fields.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+/// Editor fields: title, body, tags, mood
+/// Used in [EditorScreen]
+
+/// Title field for the editor
+class TitleField extends StatelessWidget {
+  const TitleField({super.key, required this.controller, required this.label});
+  final TextEditingController controller;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      textInputAction: TextInputAction.next,
+      decoration: InputDecoration(labelText: label),
+    );
+  }
+}
+
+/// Body field for the editor
+class BodyField extends StatelessWidget {
+  const BodyField({super.key, required this.controller, required this.label});
+  final TextEditingController controller;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      maxLines: 8,
+      decoration: InputDecoration(labelText: label),
+    );
+  }
+}
+
+/// Tag field for the editor
+class TagField extends StatelessWidget {
+  const TagField({super.key, required this.controller, required this.label});
+  final TextEditingController controller;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      decoration: InputDecoration(labelText: label),
+    );
+  }
+}
+
+/// Mood picker for the editor
+class MoodPicker extends StatelessWidget {
+  const MoodPicker({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    required this.label,
+  });
+
+  final String? value;
+  final ValueChanged<String?> onChanged;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return DropdownButton<String>(
+      value: value,
+      hint: Text(label),
+      items: const [
+        DropdownMenuItem(value: '🙂', child: Text('🙂')),
+        DropdownMenuItem(value: '😊', child: Text('😊')),
+        DropdownMenuItem(value: '😐', child: Text('😐')),
+        DropdownMenuItem(value: '😔', child: Text('😔')),
+      ],
+      onChanged: onChanged,
+    );
+  }
+}

--- a/lib/features/editor/state/editor_controller.dart
+++ b/lib/features/editor/state/editor_controller.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:havenote/domain/entries/models/entry.dart';
+import 'package:havenote/features/entries/state/entries_providers.dart';
+
+/// UI-only state for the [EditorScreen] (mood + isSaving).
+class EditorState {
+  const EditorState({this.mood, this.isSaving = false});
+
+  final String? mood;
+  final bool isSaving;
+
+  EditorState copyWith({String? mood, bool? isSaving}) {
+    return EditorState(
+      mood: mood ?? this.mood,
+      isSaving: isSaving ?? this.isSaving,
+    );
+  }
+}
+
+/// Controller for the [EditorScreen].
+/// Handles mood state and saving (create or update).
+class EditorController extends StateNotifier<EditorState> {
+  EditorController(this.ref) : super(const EditorState());
+
+  final Ref ref;
+
+  void setMood(String? value) => state = state.copyWith(mood: value);
+
+  Future<String> save({
+    String? entryId,
+    required String title,
+    required String body,
+    required List<String> tags,
+  }) async {
+    if (state.isSaving) return entryId ?? '';
+    state = state.copyWith(isSaving: true);
+    try {
+      final repo = ref.read(entriesRepositoryProvider);
+
+      // Create (no id) or reuse id
+      final id =
+          entryId ??
+          await repo.createEntry(
+            title: title,
+            body: body,
+            tags: tags,
+            mood: state.mood,
+          );
+
+      // If editing, persist text changes
+      if (entryId != null) {
+        final entry = Entry(
+          id: id,
+          title: title,
+          body: body,
+          tags: tags,
+          mood: state.mood,
+          // timestamps handled by repo
+        );
+        await repo.updateEntry(entry);
+      }
+
+      return id;
+    } finally {
+      state = state.copyWith(isSaving: false);
+    }
+  }
+}
+
+/// Provider for the [EditorController].
+/// Auto-disposes when the Editor screen is popped.
+final editorControllerProvider =
+    StateNotifierProvider.autoDispose<EditorController, EditorState>(
+      (ref) => EditorController(ref),
+    );

--- a/lib/features/entries/presentation/widgets/entry_card.dart
+++ b/lib/features/entries/presentation/widgets/entry_card.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:havenote/app/constants/app_sizes.dart';
+import 'package:havenote/domain/entries/models/entry.dart';
+
+class EntryCard extends StatelessWidget {
+  const EntryCard({super.key, required this.entry});
+  final Entry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: () {
+        // TODO(Owner): Navigate to entry details screen (not implemented yet)
+      },
+      child: Card(
+        margin: EdgeInsets.zero,
+        child: Padding(
+          padding: const EdgeInsets.all(AppSizes.padding),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      entry.title,
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: AppSizes.spaceSM),
+              Text(entry.body, maxLines: 2, overflow: TextOverflow.ellipsis),
+              const SizedBox(height: AppSizes.space),
+              Wrap(
+                spacing: AppSizes.spaceSM,
+                runSpacing: AppSizes.spaceSM,
+                children: [
+                  if (entry.mood != null) Chip(label: Text(entry.mood!)),
+                  for (final tag in entry.tags) Chip(label: Text('#$tag')),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/entries/state/entries_providers.dart
+++ b/lib/features/entries/state/entries_providers.dart
@@ -1,0 +1,28 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:havenote/data/entries/firestore_entries_repository.dart';
+import 'package:havenote/domain/entries/i_entries_repository.dart';
+import 'package:havenote/domain/entries/models/entry.dart';
+
+final entriesRepositoryProvider = Provider<IEntriesRepository>((ref) {
+  return FirestoreEntriesRepository(
+    FirebaseFirestore.instance,
+    FirebaseAuth.instance,
+  );
+});
+
+/// Stream of entries
+final entriesStreamProvider = StreamProvider.autoDispose<List<Entry>>((ref) {
+  final repo = ref.watch(entriesRepositoryProvider);
+  return repo.watchEntries();
+});
+
+/// Single entry by id (nullable if the doc is missing/deleted).
+final entryStreamProvider = StreamProvider.autoDispose.family<Entry?, String>((
+  ref,
+  id,
+) {
+  final repo = ref.watch(entriesRepositoryProvider);
+  return repo.watchEntry(id);
+});

--- a/lib/features/home/presentation/widgets/empty_states.dart
+++ b/lib/features/home/presentation/widgets/empty_states.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:havenote/app/constants/app_icons.dart';
+import 'package:havenote/app/constants/app_sizes.dart';
+import 'package:havenote/l10n/app_localizations.dart';
+
+class EmptyHomeState extends StatelessWidget {
+  const EmptyHomeState({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final t = S.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSizes.paddingXL),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              AppIcons.note,
+              size: AppSizes.iconXL,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            const SizedBox(height: AppSizes.space),
+            Text(
+              t.emptyHomeTitle,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: AppSizes.spaceSM),
+            Text(
+              t.emptyHomeBody,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -69,5 +69,14 @@
   "settingsDeleteConfirmBody": "Dadurch werden Ihr Konto und alle Notizen, einschließlich der Bilder, dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.",
   "settingsDeleteSuccess": "Ihr Konto wurde gelöscht.",
   "authReauthTitle": "Erneut authentifizieren",
-  "authReauthSubtitle": "Zu Ihrer Sicherheit bestätigen Sie bitte Ihr Passwort."
+  "authReauthSubtitle": "Zu Ihrer Sicherheit bestätigen Sie bitte Ihr Passwort.",
+  "emptyHomeTitle": "Beginnen Sie mit Ihrer ersten Notiz",
+  "emptyHomeBody": "Tippen Sie auf die Plus-Schaltfläche, um einen Tagebucheintrag hinzuzufügen.",
+  "labelTitle": "Titel",
+  "labelBody": "Was beschäftigt Sie gerade?",
+  "labelMood": "Stimmung",
+  "labelTag": "Tag hinzufügen",
+  "labelNewEntry": "Neuer Eintrag",
+  "labelEditEntry": "Eintrag bearbeiten",
+  "labelUntitled": "Ohne Titel"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -69,7 +69,16 @@
   "settingsDeleteConfirmBody": "This will permanently delete your account and all notes, including images. This action cannot be undone.",
   "settingsDeleteSuccess": "Your account has been deleted.",
   "authReauthTitle": "Reauthenticate",
-  "authReauthSubtitle": "For your security, please confirm your password."
+  "authReauthSubtitle": "For your security, please confirm your password.",
+  "emptyHomeTitle": "Start your first note",
+  "emptyHomeBody": "Tap the + button to add a journal entry.",
+  "labelTitle": "Title",
+  "labelBody": "What’s on your mind?",
+  "labelMood": "Mood",
+  "labelTag": "Add tag",
+  "labelNewEntry" : "New Entry",
+  "labelEditEntry" : "Edit Entry",
+  "labelUntitled" : "Untitled"
 }
 
   

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   firebase_auth: ^6.0.2
   firebase_core: ^4.0.0
   shared_preferences: ^2.5.3
+  cloud_firestore: ^6.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Add Entry domain models and FirestoreEntriesRepository.
- Introduce providers: entriesRepositoryProvider, entriesStreamProvider, entryStreamProvider(id).
- Home: simple entries list + FAB to create new entry.
- Editor: create/edit entry with title, body, mood, tag.