### PR TITLE
feat(entries): Gallery image add/remove + detail display

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,9 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Allow Havenote to access your photos.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Allow Havenote to use the camera.</string>
 </dict>
 </plist>

--- a/lib/data/entries/firestore_entries_repository.dart
+++ b/lib/data/entries/firestore_entries_repository.dart
@@ -1,14 +1,25 @@
+import 'dart:io';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:havenote/core/logger.dart';
 import 'package:havenote/domain/entries/i_entries_repository.dart';
 import 'package:havenote/domain/entries/models/entry.dart';
+import 'package:havenote/domain/entries/models/entry_image.dart';
+import 'package:uuid/uuid.dart';
+
+/// Firestore implementation of [IEntriesRepository].
+/// Each user has their own entries subcollection under /users/{uid}/entries.
+/// Images are stored in Firebase Storage under /users/{uid}/entries/{entryId}/{imageId}.jpg
 
 class FirestoreEntriesRepository implements IEntriesRepository {
-  FirestoreEntriesRepository(this._db, this._auth);
+  FirestoreEntriesRepository(this._db, this._auth, this._storage);
 
   final FirebaseFirestore _db;
   final FirebaseAuth _auth;
+  final FirebaseStorage _storage;
 
+  /// Returns the entries collection for the current user.
   CollectionReference<Map<String, dynamic>> _entriesCollection() {
     final uid = _auth.currentUser?.uid;
     if (uid == null) {
@@ -51,16 +62,70 @@ class FirestoreEntriesRepository implements IEntriesRepository {
       'updatedAt': FieldValue.serverTimestamp(),
       'deletedAt': null,
     });
+
     return ref.id;
   }
 
   /// Updates an existing entry. `createdAt` is not modified; `updatedAt` is set to server timestamp.
   @override
   Future<void> updateEntry(Entry entry) async {
-    final data =
-        entry.toMap()
-          ..remove('createdAt')
-          ..['updatedAt'] = FieldValue.serverTimestamp();
+    final data = <String, dynamic>{
+      'title': entry.title,
+      'body': entry.body,
+      'tags': entry.tags,
+      'mood': entry.mood,
+      'updatedAt': FieldValue.serverTimestamp(),
+    };
     await _entriesCollection().doc(entry.id).update(data);
+  }
+
+  /// Uploads an image file to Firebase Storage and adds its metadata to the entry.
+  @override
+  Future<EntryImage> uploadImage({
+    required String entryId,
+    required File file,
+  }) async {
+    final uid = _auth.currentUser!.uid;
+    final id = const Uuid().v4();
+    final imagePath = 'users/$uid/entries/$entryId/$id.jpg';
+    final ref = _storage.ref(imagePath);
+
+    try {
+      // Upload file
+      await ref.putFile(file, SettableMetadata(contentType: 'image/jpeg'));
+
+      // Create image metadata
+      final img = EntryImage(path: imagePath);
+
+      // Add image metadata to entry
+      await _entriesCollection().doc(entryId).update({
+        'images': FieldValue.arrayUnion([img.toMap()]),
+        'updatedAt': FieldValue.serverTimestamp(),
+      });
+
+      return img;
+    } catch (e) {
+      // If upload or Firestore update fails, try to delete the uploaded file.
+      Log.e('Error uploading image for $entryId: $e');
+      try {
+        await ref.delete();
+      } catch (_) {}
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> removeImage({
+    required String entryId,
+    required String imagePath,
+  }) async {
+    // Delete from Storage first
+    await _storage.ref(imagePath).delete();
+
+    // Remove image metadata from entry
+    await _entriesCollection().doc(entryId).update({
+      'images': FieldValue.arrayRemove([EntryImage(path: imagePath).toMap()]),
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
   }
 }

--- a/lib/domain/entries/i_entries_repository.dart
+++ b/lib/domain/entries/i_entries_repository.dart
@@ -1,4 +1,6 @@
+import 'dart:io';
 import 'package:havenote/domain/entries/models/entry.dart';
+import 'package:havenote/domain/entries/models/entry_image.dart';
 
 abstract class IEntriesRepository {
   /// Stream of all entries
@@ -17,4 +19,13 @@ abstract class IEntriesRepository {
 
   /// Partial or full update; repo guarantees `updatedAt` server timestamp.
   Future<void> updateEntry(Entry entry);
+
+  /// Uploads an image file to Firebase Storage and adds its metadata to the entry.
+  Future<EntryImage> uploadImage({required String entryId, required File file});
+
+  /// Removes image metadata from the entry and deletes the file from Storage.
+  Future<void> removeImage({
+    required String entryId,
+    required String imagePath,
+  });
 }

--- a/lib/domain/entries/models/entry.dart
+++ b/lib/domain/entries/models/entry.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:havenote/domain/entries/models/entry_image.dart';
 
 class Entry {
   Entry({
@@ -7,6 +8,7 @@ class Entry {
     required this.body,
     this.tags = const [],
     this.mood,
+    this.images = const [],
     this.createdAt,
     this.updatedAt,
     this.deletedAt,
@@ -17,6 +19,7 @@ class Entry {
   final String body;
   final List<String> tags;
   final String? mood;
+  final List<EntryImage> images;
   final DateTime? createdAt;
   final DateTime? updatedAt;
   final DateTime? deletedAt;
@@ -27,6 +30,7 @@ class Entry {
       'body': body,
       'tags': tags,
       'mood': mood,
+      'images': images.map((e) => e.toMap()).toList(),
       'createdAt': createdAt,
       'updatedAt': updatedAt,
       'deletedAt': deletedAt,
@@ -38,6 +42,11 @@ class Entry {
     final created = data['createdAt'];
     final updated = data['updatedAt'];
     final deleted = data['deletedAt'];
+    final imgs =
+        (data['images'] as List<dynamic>? ?? [])
+            .whereType<Map<String, dynamic>>()
+            .map(EntryImage.fromMap)
+            .toList();
 
     return Entry(
       id: doc.id,
@@ -45,6 +54,7 @@ class Entry {
       body: (data['body'] as String? ?? '').trim(),
       tags: (data['tags'] as List<dynamic>? ?? []).cast<String>(),
       mood: data['mood'] as String?,
+      images: imgs,
       createdAt: created is Timestamp ? created.toDate() : null,
       updatedAt: updated is Timestamp ? updated.toDate() : null,
       deletedAt: deleted is Timestamp ? deleted.toDate() : null,
@@ -56,6 +66,7 @@ class Entry {
     String? body,
     List<String>? tags,
     String? mood,
+    List<EntryImage>? images,
     DateTime? createdAt,
     DateTime? updatedAt,
     DateTime? deletedAt,
@@ -66,6 +77,7 @@ class Entry {
       body: body ?? this.body,
       tags: tags ?? this.tags,
       mood: mood ?? this.mood,
+      images: images ?? this.images,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
       deletedAt: deletedAt ?? this.deletedAt,

--- a/lib/domain/entries/models/entry_image.dart
+++ b/lib/domain/entries/models/entry_image.dart
@@ -1,0 +1,18 @@
+import 'package:equatable/equatable.dart';
+
+/// Metadata for an image associated with an entry.
+class EntryImage extends Equatable {
+  factory EntryImage.fromMap(Map<String, dynamic> map) {
+    return EntryImage(path: map['path'] as String);
+  }
+  const EntryImage({required this.path});
+
+  /// Path in Firebase Storage
+  /// e.g. /users/{uid}/entries/{entryId}/{imageId}.jpg
+  final String path;
+
+  Map<String, dynamic> toMap() => {'path': path};
+
+  @override
+  List<Object?> get props => [path];
+}

--- a/lib/features/editor/presentation/editor_screen.dart
+++ b/lib/features/editor/presentation/editor_screen.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:havenote/app/constants/app_icons.dart';
 import 'package:havenote/app/constants/app_sizes.dart';
+import 'package:havenote/features/editor/presentation/widgets/editor_existing_images.dart';
 import 'package:havenote/features/editor/presentation/widgets/editor_fields.dart';
+import 'package:havenote/features/editor/presentation/widgets/editor_images.dart';
 import 'package:havenote/features/editor/state/editor_controller.dart';
 import 'package:havenote/features/entries/state/entries_providers.dart';
 import 'package:havenote/l10n/app_localizations.dart';
@@ -107,7 +109,17 @@ class _EditorScreenState extends ConsumerState<EditorScreen> {
               Expanded(child: TagField(controller: _tag, label: t.labelTag)),
             ],
           ),
-          const SizedBox(height: AppSizes.space),
+
+          // Existing images (edit mode)
+          if (widget.entryId != null) ...[
+            const SizedBox(height: AppSizes.space),
+            EditorExistingImages(entryId: widget.entryId!),
+          ],
+
+          // Images picker + thumbnails
+          EditorImages(),
+
+          const SizedBox(height: AppSizes.spaceLG),
           SizedBox(
             width: double.infinity,
             child: FilledButton.icon(

--- a/lib/features/editor/presentation/widgets/editor_existing_images.dart
+++ b/lib/features/editor/presentation/widgets/editor_existing_images.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:havenote/app/constants/app_icons.dart';
+import 'package:havenote/app/constants/app_sizes.dart';
+import 'package:havenote/features/entries/presentation/widgets/storage_image_tile.dart';
+import 'package:havenote/features/entries/state/entries_providers.dart';
+import 'package:havenote/l10n/app_localizations.dart';
+
+/// Widget to display existing images for an entry in the editor.
+class EditorExistingImages extends ConsumerWidget {
+  const EditorExistingImages({super.key, required this.entryId});
+  final String entryId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final t = S.of(context);
+    final entryAsync = ref.watch(entryStreamProvider(entryId));
+    final repo = ref.read(entriesRepositoryProvider);
+
+    return entryAsync.when(
+      loading: () => const SizedBox.shrink(),
+      error: (_, __) => const SizedBox.shrink(),
+      data: (entry) {
+        if (entry == null || entry.images.isEmpty) {
+          return const SizedBox.shrink();
+        }
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              t.labelImagesSaved,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: AppSizes.spaceSM),
+            Wrap(
+              spacing: AppSizes.spaceSM,
+              runSpacing: AppSizes.spaceSM,
+              children: [
+                for (final img in entry.images)
+                  Stack(
+                    children: [
+                      StorageImageTile(path: img.path),
+                      Positioned(
+                        right: AppSizes.spaceXS,
+                        top: AppSizes.spaceXS,
+                        child: Material(
+                          color: Colors.black45,
+                          shape: const CircleBorder(),
+                          child: InkWell(
+                            customBorder: const CircleBorder(),
+                            onTap: () async {
+                              try {
+                                await repo.removeImage(
+                                  entryId: entry.id,
+                                  imagePath: img.path,
+                                );
+                                if (!context.mounted) return;
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(content: Text(t.snackImageRemoved)),
+                                );
+                              } catch (e) {
+                                if (!context.mounted) return;
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(
+                                    content: Text('${t.errorGeneric}: $e'),
+                                  ),
+                                );
+                              }
+                            },
+                            child: const Padding(
+                              padding: EdgeInsets.all(AppSizes.spaceXS),
+                              child: Icon(
+                                AppIcons.delete,
+                                size: AppSizes.iconSM,
+                                color: Colors.white,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+              ],
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/features/editor/presentation/widgets/editor_images.dart
+++ b/lib/features/editor/presentation/widgets/editor_images.dart
@@ -1,0 +1,109 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:havenote/app/constants/app_icons.dart';
+import 'package:havenote/app/constants/app_sizes.dart';
+import 'package:havenote/features/editor/state/editor_controller.dart';
+import 'package:havenote/l10n/app_localizations.dart';
+import 'package:image_picker/image_picker.dart';
+
+/// Widget to pick images from gallery and display thumbnails of picked images.
+class EditorImages extends ConsumerWidget {
+  EditorImages({super.key});
+
+  final _picker = ImagePicker();
+
+  Future<void> _pick(BuildContext context, WidgetRef ref) async {
+    final x = await _picker.pickImage(
+      source: ImageSource.gallery,
+      imageQuality: 85, // TODO(Owner): adjust as needed
+    );
+    if (x == null) return;
+    ref.read(editorControllerProvider.notifier).addPicked(File(x.path));
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final t = S.of(context);
+    final state = ref.watch(editorControllerProvider);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (state.picked.isNotEmpty) ...[
+          Text(
+            t.labelImagesNew,
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: AppSizes.space),
+          Wrap(
+            spacing: AppSizes.spaceSM,
+            runSpacing: AppSizes.spaceSM,
+            children: [
+              for (final f in state.picked)
+                _Thumb(
+                  file: f,
+                  onRemove:
+                      () => ref
+                          .read(editorControllerProvider.notifier)
+                          .removePicked(f),
+                ),
+            ],
+          ),
+        ],
+        const SizedBox(height: AppSizes.space),
+        OutlinedButton.icon(
+          onPressed: () => _pick(context, ref),
+          icon: const Icon(AppIcons.image, size: AppSizes.icon),
+          label: Text(t.labelAddImage),
+        ),
+      ],
+    );
+  }
+}
+
+/// A simple frame around images to ensure consistent sizing and aspect ratio.
+class _Thumb extends StatelessWidget {
+  const _Thumb({required this.file, required this.onRemove});
+
+  final File file;
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        ClipRRect(
+          borderRadius: BorderRadius.circular(AppSizes.radiusLG),
+          child: Container(
+            width: 128,
+            height: 128,
+            color: Colors.black12,
+            child: Image.file(file, fit: BoxFit.cover),
+          ),
+        ),
+        Positioned(
+          right: AppSizes.spaceXS,
+          top: AppSizes.spaceXS,
+          child: Material(
+            color: Colors.black45,
+            shape: const CircleBorder(),
+            child: InkWell(
+              customBorder: const CircleBorder(),
+              onTap: onRemove,
+              child: const Padding(
+                padding: EdgeInsets.all(AppSizes.spaceXS),
+                child: Icon(
+                  Icons.close,
+                  size: AppSizes.icon,
+                  color: Colors.white,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/editor/state/editor_controller.dart
+++ b/lib/features/editor/state/editor_controller.dart
@@ -1,30 +1,43 @@
+import 'dart:io';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:havenote/domain/entries/models/entry.dart';
 import 'package:havenote/features/entries/state/entries_providers.dart';
 
-/// UI-only state for the [EditorScreen] (mood + isSaving).
+/// UI-only state for the [EditorScreen] (for mood, isSaving & picked images).
 class EditorState {
-  const EditorState({this.mood, this.isSaving = false});
+  const EditorState({
+    this.mood,
+    this.isSaving = false,
+    this.picked = const <File>[],
+  });
 
   final String? mood;
   final bool isSaving;
+  final List<File> picked;
 
-  EditorState copyWith({String? mood, bool? isSaving}) {
+  EditorState copyWith({String? mood, bool? isSaving, List<File>? picked}) {
     return EditorState(
       mood: mood ?? this.mood,
       isSaving: isSaving ?? this.isSaving,
+      picked: picked ?? this.picked,
     );
   }
 }
 
-/// Controller for the [EditorScreen].
-/// Handles mood state and saving (create or update).
 class EditorController extends StateNotifier<EditorState> {
   EditorController(this.ref) : super(const EditorState());
 
   final Ref ref;
 
   void setMood(String? value) => state = state.copyWith(mood: value);
+
+  void addPicked(File file) =>
+      state = state.copyWith(picked: [...state.picked, file]);
+
+  void removePicked(File file) =>
+      state = state.copyWith(
+        picked: state.picked.where((f) => f.path != file.path).toList(),
+      );
 
   Future<String> save({
     String? entryId,
@@ -47,7 +60,7 @@ class EditorController extends StateNotifier<EditorState> {
             mood: state.mood,
           );
 
-      // If editing, persist text changes
+      // If editing, persist text changes (images handled below)
       if (entryId != null) {
         final entry = Entry(
           id: id,
@@ -55,11 +68,19 @@ class EditorController extends StateNotifier<EditorState> {
           body: body,
           tags: tags,
           mood: state.mood,
-          // timestamps handled by repo
+          images: const [],
+          // timestamps handled by repo; values here are ignored on update
         );
         await repo.updateEntry(entry);
       }
 
+      // Upload newly picked images
+      for (final f in state.picked) {
+        await repo.uploadImage(entryId: id, file: f);
+      }
+
+      // Clear picked queue after successful save
+      state = state.copyWith(picked: const []);
       return id;
     } finally {
       state = state.copyWith(isSaving: false);
@@ -67,8 +88,6 @@ class EditorController extends StateNotifier<EditorState> {
   }
 }
 
-/// Provider for the [EditorController].
-/// Auto-disposes when the Editor screen is popped.
 final editorControllerProvider =
     StateNotifierProvider.autoDispose<EditorController, EditorState>(
       (ref) => EditorController(ref),

--- a/lib/features/entries/presentation/widgets/storage_image_tile.dart
+++ b/lib/features/entries/presentation/widgets/storage_image_tile.dart
@@ -1,0 +1,81 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:havenote/app/constants/app_sizes.dart';
+import 'package:havenote/core/logger.dart';
+import 'package:havenote/features/entries/state/entries_providers.dart';
+
+/// Widget to display an image from storage, handling local files and remote URLs.
+class StorageImageTile extends ConsumerWidget {
+  const StorageImageTile({super.key, required this.path});
+  final String path;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!kIsWeb && path.startsWith('local://')) {
+      final file = File(path.replaceFirst('local://', ''));
+      return _Framed(child: Image.file(file, fit: BoxFit.cover));
+    }
+
+    final urlAsync = ref.watch(storageDownloadUrlProvider(path));
+
+    return urlAsync.when(
+      loading: () {
+        return const _Framed(
+          child: SizedBox(
+            width: AppSizes.icon,
+            height: AppSizes.icon,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+        );
+      },
+      error: (e, _) {
+        Log.e('Image: Error loading storage URL for path=$path: $e');
+        return const _Framed(child: Center(child: Text('!')));
+      },
+      data: (url) {
+        return _Framed(
+          child: Image.network(
+            url,
+            fit: BoxFit.cover,
+            loadingBuilder: (context, child, loadingProgress) {
+              if (loadingProgress == null) return child;
+
+              // Show progress indicator while loading
+              return Center(
+                child: CircularProgressIndicator(
+                  value:
+                      loadingProgress.expectedTotalBytes != null
+                          ? loadingProgress.cumulativeBytesLoaded /
+                              (loadingProgress.expectedTotalBytes ?? 1)
+                          : null,
+                ),
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// A simple frame around images to ensure consistent sizing and aspect ratio.
+class _Framed extends StatelessWidget {
+  const _Framed({required this.child});
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(AppSizes.radiusLG),
+      child: Container(
+        width: 128,
+        height: 128,
+        color: Colors.black12,
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/features/entries/state/entries_providers.dart
+++ b/lib/features/entries/state/entries_providers.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:havenote/data/entries/firestore_entries_repository.dart';
 import 'package:havenote/domain/entries/i_entries_repository.dart';
@@ -9,6 +10,7 @@ final entriesRepositoryProvider = Provider<IEntriesRepository>((ref) {
   return FirestoreEntriesRepository(
     FirebaseFirestore.instance,
     FirebaseAuth.instance,
+    FirebaseStorage.instance,
   );
 });
 
@@ -25,4 +27,13 @@ final entryStreamProvider = StreamProvider.autoDispose.family<Entry?, String>((
 ) {
   final repo = ref.watch(entriesRepositoryProvider);
   return repo.watchEntry(id);
+});
+
+/// Resolves a Firebase Storage fullPath to a download URL.
+final storageDownloadUrlProvider = FutureProvider.family<String, String>((
+  ref,
+  path,
+) async {
+  final refStorage = FirebaseStorage.instance.ref(path);
+  return refStorage.getDownloadURL();
 });

--- a/lib/features/entry_detail/presentation/entry_detail_screen.dart
+++ b/lib/features/entry_detail/presentation/entry_detail_screen.dart
@@ -7,6 +7,7 @@ import 'package:havenote/app/constants/app_sizes.dart';
 import 'package:havenote/app/router/routes.dart';
 import 'package:havenote/features/entries/state/entries_providers.dart';
 import 'package:havenote/features/entry_detail/presentation/widgets/entry_header.dart';
+import 'package:havenote/features/entry_detail/presentation/widgets/entry_images_grid.dart';
 import 'package:havenote/l10n/app_localizations.dart';
 
 class EntryDetailScreen extends ConsumerWidget {
@@ -68,6 +69,17 @@ class EntryDetailScreen extends ConsumerWidget {
                   ),
                 ),
               ),
+
+              // Images section
+              if (entry.images.isNotEmpty) ...[
+                const SizedBox(height: AppSizes.spaceLG),
+                Text(
+                  t.labelImages,
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: AppSizes.spaceSM),
+                EntryImagesGrid(entry: entry),
+              ],
             ],
           ),
         );

--- a/lib/features/entry_detail/presentation/widgets/entry_images_grid.dart
+++ b/lib/features/entry_detail/presentation/widgets/entry_images_grid.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:havenote/app/constants/app_sizes.dart';
+import 'package:havenote/domain/entries/models/entry.dart';
+import 'package:havenote/features/entries/presentation/widgets/storage_image_tile.dart';
+
+/// Widget to display a grid of images for an entry.
+class EntryImagesGrid extends StatelessWidget {
+  const EntryImagesGrid({super.key, required this.entry});
+  final Entry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: AppSizes.spaceSM,
+      runSpacing: AppSizes.spaceSM,
+      children: [
+        for (final img in entry.images) StorageImageTile(path: img.path),
+      ],
+    );
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -80,5 +80,10 @@
   "labelEditEntry": "Eintrag bearbeiten",
   "labelUntitled": "Ohne Titel",
   "labelEntry": "Eintrag",
-  "tooltipEdit": "Bearbeiten"
+  "tooltipEdit": "Bearbeiten",
+  "labelAddImage": "Bilder hinzufügen",
+  "labelImages": "Bilder",
+  "labelImagesSaved": "Gespeicherte Bilder",
+  "labelImagesNew": "Neue Bilder",
+  "snackImageRemoved": "Bild entfernt"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -80,5 +80,10 @@
   "labelEditEntry" : "Edit Entry",
   "labelUntitled" : "Untitled",
   "labelEntry": "Entry",
-  "tooltipEdit": "Edit"
+  "tooltipEdit": "Edit",
+  "labelAddImage": "Add Images",
+  "labelImages": "Images",
+  "labelImagesSaved" : "Saved images",
+  "labelImagesNew" : "New images",
+  "snackImageRemoved" : "Image Removed"
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,10 @@ dependencies:
   firebase_core: ^4.0.0
   shared_preferences: ^2.5.3
   cloud_firestore: ^6.0.1
+  equatable: ^2.0.7
+  firebase_storage: ^13.0.1
+  image_picker: ^1.2.0
+  uuid: ^4.5.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
* **Editor**: pick images from gallery (thumbnails shown), save uploads to Firebase Storage (UUID filenames, image/jpeg), Firestore images array updated.
* **Detail**: render images grid via cached download URLs; support removing images from an entry.
* **Repo**: wire up uploadImage / removeImage; client-side filter for deleted entries remains.

**Note**:
               Testing status- verified on iOS Simulator only. Testing on an actual Android/iOS device is pending.