### PR TITLE
feat(home): Add search feature in home screen

### DIFF
--- a/lib/app/constants/app_sizes.dart
+++ b/lib/app/constants/app_sizes.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/material.dart';
+
 /// Global spacing/radius/icon sizes for the app
 class AppSizes {
   // Padding
@@ -29,6 +31,9 @@ class AppSizes {
 
   // Button height
   static const double buttonHeight = 48;
+
+  // Search field height
+  static const double searchFieldHeight = kToolbarHeight + space;
 
   // Other
   static const double dividerThickness = 1;

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -5,8 +5,9 @@ import 'package:havenote/app/constants/app_icons.dart';
 import 'package:havenote/app/constants/app_sizes.dart';
 import 'package:havenote/app/router/routes.dart';
 import 'package:havenote/features/entries/presentation/widgets/entry_card.dart';
-import 'package:havenote/features/entries/state/entries_providers.dart';
 import 'package:havenote/features/home/presentation/widgets/empty_states.dart';
+import 'package:havenote/features/home/presentation/widgets/home_search_field.dart';
+import 'package:havenote/features/home/state/home_filters.dart';
 import 'package:havenote/l10n/app_localizations.dart';
 
 class HomeScreen extends ConsumerWidget {
@@ -15,7 +16,8 @@ class HomeScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final t = S.of(context);
-    final entriesAsync = ref.watch(entriesStreamProvider);
+    final filters = ref.watch(homeFiltersProvider);
+    final entriesAsync = ref.watch(filteredEntriesProvider);
 
     return Scaffold(
       appBar: AppBar(
@@ -26,13 +28,22 @@ class HomeScreen extends ConsumerWidget {
             onPressed: () => context.push(AppRoute.settings()),
           ),
         ],
+        bottom: const PreferredSize(
+          preferredSize: Size.fromHeight(AppSizes.searchFieldHeight),
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: AppSizes.padding),
+            child: HomeSearchField(),
+          ),
+        ),
       ),
       body: entriesAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, _) => Center(child: Text('${t.errorGeneric}: $e')),
         data: (entries) {
           if (entries.isEmpty) {
-            return const EmptyHomeState();
+            return filters.query.isEmpty
+                ? const EmptyHomeState()
+                : const EmptySearchState();
           }
           return ListView.separated(
             padding: const EdgeInsets.all(AppSizes.padding),

--- a/lib/features/home/presentation/widgets/empty_states.dart
+++ b/lib/features/home/presentation/widgets/empty_states.dart
@@ -3,6 +3,7 @@ import 'package:havenote/app/constants/app_icons.dart';
 import 'package:havenote/app/constants/app_sizes.dart';
 import 'package:havenote/l10n/app_localizations.dart';
 
+/// Widget to display when there are no entries in the home screen.
 class EmptyHomeState extends StatelessWidget {
   const EmptyHomeState({super.key});
 
@@ -28,6 +29,41 @@ class EmptyHomeState extends StatelessWidget {
             const SizedBox(height: AppSizes.spaceSM),
             Text(
               t.emptyHomeBody,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Widget to display when there are no search results in the home screen.
+class EmptySearchState extends StatelessWidget {
+  const EmptySearchState({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final t = S.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSizes.paddingXL),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              AppIcons.search,
+              size: AppSizes.iconXL,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            const SizedBox(height: AppSizes.space),
+            Text(
+              t.emptySearchTitle,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: AppSizes.spaceSM),
+            Text(
+              t.emptySearchBody,
               style: Theme.of(context).textTheme.bodyMedium,
             ),
           ],

--- a/lib/features/home/presentation/widgets/home_search_field.dart
+++ b/lib/features/home/presentation/widgets/home_search_field.dart
@@ -1,0 +1,67 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:havenote/app/constants/app_icons.dart';
+import 'package:havenote/features/home/state/home_filters.dart';
+import 'package:havenote/l10n/app_localizations.dart';
+
+/// Search field widget for the home screen.
+class HomeSearchField extends ConsumerStatefulWidget {
+  const HomeSearchField({super.key});
+
+  @override
+  ConsumerState<HomeSearchField> createState() => _HomeSearchFieldState();
+}
+
+class _HomeSearchFieldState extends ConsumerState<HomeSearchField> {
+  final _controller = TextEditingController();
+  Timer? _debounce;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.text = ref.read(homeFiltersProvider).query; // initial value
+    _controller.addListener(() => setState(() {})); // to update suffixIcon
+  }
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    _controller.removeListener(() => setState(() {}));
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _onChanged(String value) {
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 250), () {
+      ref.read(homeFiltersProvider.notifier).setQuery(value);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final t = S.of(context);
+    final hasText = _controller.text.isNotEmpty;
+
+    return TextField(
+      controller: _controller,
+      onChanged: _onChanged,
+      decoration: InputDecoration(
+        prefixIcon: const Icon(AppIcons.search),
+        hintText: t.hintSearch,
+        suffixIcon:
+            hasText
+                ? IconButton(
+                  tooltip: t.actionClear,
+                  icon: const Icon(Icons.clear),
+                  onPressed: () {
+                    _controller.clear();
+                    _onChanged('');
+                  },
+                )
+                : null,
+      ),
+    );
+  }
+}

--- a/lib/features/home/state/home_filters.dart
+++ b/lib/features/home/state/home_filters.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:havenote/domain/entries/models/entry.dart';
+import 'package:havenote/features/entries/state/entries_providers.dart';
+
+/// UI-only state for the Home screen (search).
+class HomeFiltersState {
+  const HomeFiltersState({this.query = ''});
+
+  final String query;
+
+  HomeFiltersState copyWith({String? query}) {
+    return HomeFiltersState(query: query ?? this.query);
+  }
+}
+
+/// StateNotifier to manage [HomeFiltersState].
+class HomeFiltersController extends StateNotifier<HomeFiltersState> {
+  HomeFiltersController() : super(const HomeFiltersState());
+
+  void setQuery(String value) =>
+      state = state.copyWith(query: value.trim().toLowerCase());
+}
+
+/// Provider for [HomeFiltersController] and its state.
+final homeFiltersProvider =
+    StateNotifierProvider<HomeFiltersController, HomeFiltersState>(
+      (ref) => HomeFiltersController(),
+    );
+
+/// Combines entries stream with UI filters into a single AsyncValue.
+final filteredEntriesProvider = Provider.autoDispose<AsyncValue<List<Entry>>>((
+  ref,
+) {
+  final filters = ref.watch(homeFiltersProvider);
+  final entriesAsync = ref.watch(entriesStreamProvider);
+
+  return entriesAsync.whenData((entries) {
+    final q = filters.query;
+    if (q.isEmpty) return entries;
+
+    // Simple search: title or body contains the query (case insensitive).
+    // TODO(owner): improve with tags, mood, date, etc.
+    return entries
+        .where((e) => ('${e.title}\n${e.body}').toLowerCase().contains(q))
+        .toList(growable: false);
+  });
+});

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -10,6 +10,7 @@
   "actionCancel": "Abbrechen",
   "actionDelete": "Löschen",
   "actionConfirm": "Bestätigen",
+  "actionClear": "Leeren",
   "actionShow": "Anzeigen",
   "actionHide": "Ausblenden",
   "labelEmail": "E-Mail",
@@ -85,5 +86,8 @@
   "labelImages": "Bilder",
   "labelImagesSaved": "Gespeicherte Bilder",
   "labelImagesNew": "Neue Bilder",
-  "snackImageRemoved": "Bild entfernt"
+  "snackImageRemoved": "Bild entfernt",
+  "emptySearchTitle": "Keine passenden Notizen",
+  "emptySearchBody": "Versuchen Sie ein anderes Stichwort.",
+  "hintSearch": "Notizen durchsuchen…"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -10,6 +10,7 @@
   "actionCancel": "Cancel",
   "actionDelete": "Delete",
   "actionConfirm": "Confirm",
+  "actionClear": "Clear",
   "actionShow": "Show",
   "actionHide": "Hide",
   "labelEmail": "Email",
@@ -85,5 +86,8 @@
   "labelImages": "Images",
   "labelImagesSaved" : "Saved images",
   "labelImagesNew" : "New images",
-  "snackImageRemoved" : "Image Removed"
+  "snackImageRemoved" : "Image Removed",
+  "emptySearchTitle": "No matching notes",
+  "emptySearchBody": "Try a different keyword.",
+  "hintSearch": "Search notes…"
 }


### PR DESCRIPTION
- Add **homeFiltersProvider** + **HomeFiltersController** (UI-only search state).
- Add **filteredEntriesProvider** to combine entries stream with query.
- Implement **HomeSearchField** with 250 ms debounce and a clear button.
- Simple search: title or body contains the search query.