### PR TITLE
feat(entries): soft delete (via swipe & detail) & show deleted option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,29 @@
 > Write daily entries, attach photos, tag moods — even offline. Data syncs when you’re back online.
 
 ## Overview
-**Havenote** is an offline-first personal journal:
-- Write daily entries, attach photos, tag moods.
-- Full offline support with automatic sync when online.
-- Cloud backup + device restore.
-- End-to-end encryption demo (local + Firestore).
+**Havenote** is personal journal. Write entries, add photos, and tag moods—everything works offline and syncs automatically when back online.
 
-Firebase used: **Auth**, **Firestore** (with offline persistence), **Storage**.
+- Entries with title/body, mood, tags
+- Add photos from gallery; images stored in Firebase Storage
+- Soft delete (Recently Deleted) with restore
+- Debounced search on Home; toggle to show/hide deleted
+- Clean Architecture + Riverpod + GoRouter
+- Material 3 theming (light/dark), EN/DE localization
+
+Firebase used: **Auth**, **Firestore** (offline persistence), **Storage**.
 
 ## Implemented so far
 - **Auth (email & password)**: sign up, sign in, sign out  
 - **Verify email**: resend + “I’ve verified” check  
 - **Forgot password**: reset link  
-- **Routing**: GoRouter with guarded routes; Splash handles first navigation  
+- **Routing**: GoRouter with guards; Splash handles first navigation
+- **Settings**: theme mode (system/light/dark), edit display name, sign out, delete account
+- **Entries**
+  - Repository: Firestore (offline-first), Storage for images
+  - Home: list of entries, **debounced search**, **show deleted** toggle
+  - List swipe: **soft delete/restore** with Undo snackbar
+  - Detail: title/body, mood, tags, **images grid**
+  - Editor: create/edit (title, body, mood, single tag), **pick & upload images**
 - **Architecture**: Clean Architecture + Riverpod providers  
 - **UI**: Sign In, Sign Up, Verify Email, Forgot Password, Home (placeholder card)  
 - **Theming**: Material 3 (light/dark)  

--- a/lib/app/constants/app_icons.dart
+++ b/lib/app/constants/app_icons.dart
@@ -19,6 +19,7 @@ class AppIcons {
   // Notes
   static const note = Icons.menu_book_rounded;
   static const edit = Icons.edit;
+  static const restore = Icons.restore_from_trash;
 
   // Media
   static const image = Icons.image_outlined;

--- a/lib/domain/entries/i_entries_repository.dart
+++ b/lib/domain/entries/i_entries_repository.dart
@@ -4,7 +4,7 @@ import 'package:havenote/domain/entries/models/entry_image.dart';
 
 abstract class IEntriesRepository {
   /// Stream of all entries
-  Stream<List<Entry>> watchEntries();
+  Stream<List<Entry>> watchEntries({bool includeDeleted = false});
 
   /// Stream of a single entry by id (nullable if the doc is missing/deleted).
   Stream<Entry?> watchEntry(String id);
@@ -28,4 +28,10 @@ abstract class IEntriesRepository {
     required String entryId,
     required String imagePath,
   });
+
+  /// Soft-deletes (sets `deletedAt` to server timestamp).
+  Future<void> softDelete(String entryId);
+
+  /// Restores a soft-deleted entry (sets `deletedAt` to null).
+  Future<void> restore(String entryId);
 }

--- a/lib/features/auth/utils/auth_error_mapper.dart
+++ b/lib/features/auth/utils/auth_error_mapper.dart
@@ -40,6 +40,10 @@ String mapAuthError(Object error, S t) {
     case 'network-request-failed':
       return t.authErrorNetworkRequestFailed;
 
+    // case 'requires-recent-login':
+    // case 'user-mismatch': // reauth with a different user than current
+    //   return t.settingsDeleteRequiresReauthentication;
+
     // Account state
     case 'user-disabled':
       return t.authErrorUserDisabled;

--- a/lib/features/entries/presentation/widgets/dismissible_entry.dart
+++ b/lib/features/entries/presentation/widgets/dismissible_entry.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:havenote/app/constants/app_icons.dart';
+import 'package:havenote/app/constants/app_sizes.dart';
+import 'package:havenote/domain/entries/models/entry.dart';
+import 'package:havenote/features/entries/presentation/widgets/entry_card.dart';
+import 'package:havenote/features/entries/state/entries_providers.dart';
+import 'package:havenote/l10n/app_localizations.dart';
+
+/// A Dismissible widget that wraps an EntryCard and allows swipe-to-delete/restore.
+class DismissibleEntry extends ConsumerWidget {
+  const DismissibleEntry({
+    super.key,
+    required this.entry,
+    required this.showDeleted,
+  });
+
+  final Entry entry;
+  final bool showDeleted;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final repo = ref.read(entriesRepositoryProvider);
+    final deleted = entry.deletedAt != null;
+    final t = S.of(context);
+    final cs = Theme.of(context).colorScheme;
+
+    Future<bool> toggle() async {
+      try {
+        if (deleted) {
+          await repo.restore(entry.id);
+          if (context.mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(t.snackRestored),
+                action: SnackBarAction(
+                  label: t.labelUndo,
+                  onPressed: () => repo.softDelete(entry.id),
+                ),
+              ),
+            );
+          }
+        } else {
+          await repo.softDelete(entry.id);
+          if (context.mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(t.snackMovedToDeleted),
+                action: SnackBarAction(
+                  label: t.labelUndo,
+                  onPressed: () => repo.restore(entry.id),
+                ),
+              ),
+            );
+          }
+        }
+        return !showDeleted; // keep in list if viewing deleted
+      } catch (e) {
+        if (context.mounted) {
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text('${t.errorGeneric}: $e')));
+        }
+        return false;
+      }
+    }
+
+    return Dismissible(
+      key: ValueKey(entry.id),
+      direction: DismissDirection.endToStart,
+      background: _DismissBackground(
+        color: deleted ? Colors.green : cs.error,
+        icon: deleted ? AppIcons.restore : AppIcons.delete,
+        alignEnd: true,
+      ),
+      confirmDismiss: (_) => toggle(),
+      child: EntryCard(entry: entry),
+    );
+  }
+}
+
+/// The background widget shown behind the Dismissible.
+class _DismissBackground extends StatelessWidget {
+  const _DismissBackground({
+    required this.color,
+    required this.icon,
+    this.alignEnd = false,
+  });
+
+  final Color color;
+  final IconData icon;
+  final bool alignEnd;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      alignment: alignEnd ? Alignment.centerRight : Alignment.centerLeft,
+      padding: const EdgeInsets.symmetric(horizontal: AppSizes.padding),
+      color: color.withValues(alpha: 0.15),
+      child: Icon(icon, color: color, size: AppSizes.iconLG),
+    );
+  }
+}

--- a/lib/features/entries/presentation/widgets/soft_delete_action.dart
+++ b/lib/features/entries/presentation/widgets/soft_delete_action.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:havenote/app/constants/app_icons.dart';
+import 'package:havenote/features/entries/state/entries_providers.dart';
+import 'package:havenote/l10n/app_localizations.dart';
+
+/// An IconButton that performs soft-delete or restore action on an entry.
+class SoftDeleteRestoreAction extends ConsumerWidget {
+  const SoftDeleteRestoreAction({
+    super.key,
+    required this.entryId,
+    required this.deleted,
+  });
+
+  final String entryId;
+  final bool deleted;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final t = S.of(context);
+    final repo = ref.read(entriesRepositoryProvider);
+
+    return IconButton(
+      icon: Icon(deleted ? AppIcons.restore : AppIcons.delete),
+      tooltip: deleted ? t.tooltipRestore : t.tooltipDelete,
+      onPressed: () async {
+        try {
+          if (deleted) {
+            await repo.restore(entryId);
+            if (context.mounted) {
+              ScaffoldMessenger.of(
+                context,
+              ).showSnackBar(SnackBar(content: Text(t.snackRestored)));
+            }
+          } else {
+            await repo.softDelete(entryId);
+            if (context.mounted) {
+              ScaffoldMessenger.of(
+                context,
+              ).showSnackBar(SnackBar(content: Text(t.snackMovedToDeleted)));
+            }
+          }
+        } catch (e) {
+          if (!context.mounted) return;
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text('${t.errorGeneric}: $e')));
+        }
+      },
+    );
+  }
+}

--- a/lib/features/entries/state/entries_providers.dart
+++ b/lib/features/entries/state/entries_providers.dart
@@ -14,11 +14,12 @@ final entriesRepositoryProvider = Provider<IEntriesRepository>((ref) {
   );
 });
 
-/// Stream of entries
-final entriesStreamProvider = StreamProvider.autoDispose<List<Entry>>((ref) {
-  final repo = ref.watch(entriesRepositoryProvider);
-  return repo.watchEntries();
-});
+/// Stream of entries; pass `includeDeleted=true` to also receive soft-deleted.
+final entriesStreamProvider = StreamProvider.autoDispose
+    .family<List<Entry>, bool>((ref, includeDeleted) {
+      final repo = ref.watch(entriesRepositoryProvider);
+      return repo.watchEntries(includeDeleted: includeDeleted);
+    });
 
 /// Single entry by id (nullable if the doc is missing/deleted).
 final entryStreamProvider = StreamProvider.autoDispose.family<Entry?, String>((

--- a/lib/features/entry_detail/presentation/entry_detail_screen.dart
+++ b/lib/features/entry_detail/presentation/entry_detail_screen.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:havenote/app/constants/app_icons.dart';
 import 'package:havenote/app/constants/app_sizes.dart';
 import 'package:havenote/app/router/routes.dart';
+import 'package:havenote/features/entries/presentation/widgets/soft_delete_action.dart';
 import 'package:havenote/features/entries/state/entries_providers.dart';
 import 'package:havenote/features/entry_detail/presentation/widgets/entry_header.dart';
 import 'package:havenote/features/entry_detail/presentation/widgets/entry_images_grid.dart';
@@ -50,6 +51,7 @@ class EntryDetailScreen extends ConsumerWidget {
                         ? null
                         : () => context.push(AppRoute.editorEdit(entry.id)),
               ),
+              SoftDeleteRestoreAction(entryId: entry.id, deleted: deleted),
             ],
           ),
           body: ListView(

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -4,7 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:havenote/app/constants/app_icons.dart';
 import 'package:havenote/app/constants/app_sizes.dart';
 import 'package:havenote/app/router/routes.dart';
-import 'package:havenote/features/entries/presentation/widgets/entry_card.dart';
+import 'package:havenote/features/entries/presentation/widgets/dismissible_entry.dart';
 import 'package:havenote/features/home/presentation/widgets/empty_states.dart';
 import 'package:havenote/features/home/presentation/widgets/home_search_field.dart';
 import 'package:havenote/features/home/state/home_filters.dart';
@@ -23,6 +23,18 @@ class HomeScreen extends ConsumerWidget {
       appBar: AppBar(
         title: Text(t.appTitle),
         actions: [
+          IconButton(
+            icon: Icon(
+              filters.showDeleted ? AppIcons.restore : AppIcons.delete,
+            ),
+            tooltip:
+                filters.showDeleted
+                    ? t.tooltipHideDeleted
+                    : t.tooltipShowDeleted,
+            onPressed:
+                () =>
+                    ref.read(homeFiltersProvider.notifier).toggleShowDeleted(),
+          ),
           IconButton(
             icon: const Icon(AppIcons.settings),
             onPressed: () => context.push(AppRoute.settings()),
@@ -51,7 +63,12 @@ class HomeScreen extends ConsumerWidget {
             separatorBuilder: (_, __) => const SizedBox(height: AppSizes.space),
             itemBuilder: (_, i) {
               final entry = entries[i];
-              return EntryCard(entry: entry);
+
+              return DismissibleEntry(
+                key: ValueKey(entry.id),
+                entry: entry,
+                showDeleted: filters.showDeleted,
+              );
             },
           );
         },

--- a/lib/features/home/state/home_filters.dart
+++ b/lib/features/home/state/home_filters.dart
@@ -4,12 +4,16 @@ import 'package:havenote/features/entries/state/entries_providers.dart';
 
 /// UI-only state for the Home screen (search).
 class HomeFiltersState {
-  const HomeFiltersState({this.query = ''});
+  const HomeFiltersState({this.query = '', this.showDeleted = false});
 
   final String query;
+  final bool showDeleted;
 
-  HomeFiltersState copyWith({String? query}) {
-    return HomeFiltersState(query: query ?? this.query);
+  HomeFiltersState copyWith({String? query, bool? showDeleted}) {
+    return HomeFiltersState(
+      query: query ?? this.query,
+      showDeleted: showDeleted ?? this.showDeleted,
+    );
   }
 }
 
@@ -19,6 +23,9 @@ class HomeFiltersController extends StateNotifier<HomeFiltersState> {
 
   void setQuery(String value) =>
       state = state.copyWith(query: value.trim().toLowerCase());
+
+  void toggleShowDeleted() =>
+      state = state.copyWith(showDeleted: !state.showDeleted);
 }
 
 /// Provider for [HomeFiltersController] and its state.
@@ -32,14 +39,14 @@ final filteredEntriesProvider = Provider.autoDispose<AsyncValue<List<Entry>>>((
   ref,
 ) {
   final filters = ref.watch(homeFiltersProvider);
-  final entriesAsync = ref.watch(entriesStreamProvider);
+  final entriesAsync = ref.watch(entriesStreamProvider(filters.showDeleted));
 
   return entriesAsync.whenData((entries) {
     final q = filters.query;
     if (q.isEmpty) return entries;
 
     // Simple search: title or body contains the query (case insensitive).
-    // TODO(owner): improve with tags, mood, date, etc.
+    // TODO(Owner): improve with tags, mood, date, etc.
     return entries
         .where((e) => ('${e.title}\n${e.body}').toLowerCase().contains(q))
         .toList(growable: false);

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -89,5 +89,12 @@
   "snackImageRemoved": "Bild entfernt",
   "emptySearchTitle": "Keine passenden Notizen",
   "emptySearchBody": "Versuchen Sie ein anderes Stichwort.",
-  "hintSearch": "Notizen durchsuchen…"
+  "hintSearch": "Notizen durchsuchen…",
+  "tooltipShowDeleted": "Gelöschte anzeigen",
+  "tooltipHideDeleted": "Gelöschte ausblenden",
+  "tooltipDelete": "Löschen",
+  "tooltipRestore": "Wiederherstellen",
+  "snackMovedToDeleted": "In \"Zuletzt gelöscht\" verschoben",
+  "snackRestored": "Wiederhergestellt",
+  "labelUndo": "Rückgängig"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -89,5 +89,12 @@
   "snackImageRemoved" : "Image Removed",
   "emptySearchTitle": "No matching notes",
   "emptySearchBody": "Try a different keyword.",
-  "hintSearch": "Search notes…"
+  "hintSearch": "Search notes…",
+  "tooltipShowDeleted": "Show deleted",
+  "tooltipHideDeleted": "Hide deleted",
+  "tooltipDelete": "Delete",
+  "tooltipRestore": "Restore",
+  "snackMovedToDeleted": "Moved to \"Recently Deleted\"",
+  "snackRestored": "Restored",
+  "labelUndo": "Undo"
 }


### PR DESCRIPTION
- Add soft delete via list swipe (**DismissibleEntry**) with Undo snackbar.
- Add restore/delete action in Entry Detail (**SoftDeleteRestoreAction**).
- Add “Show deleted” toggle on Home; deleted items appear with reduced emphasis.
- **Note**: Permanent delete is not yet implemented.
- Updated Readme doc